### PR TITLE
add option to append matchgroup ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docs/_build/
 !/scripts/userscripts/__init__.py
 .vscode/
 **/.DS_Store
+idCache/idList.txt

--- a/pywikibot/textlib.py
+++ b/pywikibot/textlib.py
@@ -389,14 +389,14 @@ def getID( i ):
     if not checkUnique(id):
         id = getID( i + 100 )
 
-    with open('idCache\idList.txt', 'a') as idList:
+    with open('idCache/idList.txt', 'a') as idList:
         idList.write('\n' + id)
 
     return id
 
 def checkUnique( id ):
     #open ID List
-    with open('idCache\idList.txt', 'r') as read_obj:
+    with open('idCache/idList.txt', 'r') as read_obj:
         #read all lines
         for line in read_obj:
             if id in line:

--- a/pywikibot/textlib.py
+++ b/pywikibot/textlib.py
@@ -368,6 +368,43 @@ def get_regexes(
     return result
 
 
+def getID( i ):
+    from random import seed
+    from random import randint
+    import time
+
+    seed( int(time.time()) + i )
+
+    id = ''
+
+    for _ in range(10):
+        value = randint(1, 62)
+        if value <= 10:
+            id = id + str(value - 1)
+        elif value <= 36:
+            id = id + chr(value + 54)
+        else:
+            id = id + chr(value + 60)
+
+    if not checkUnique(id):
+        id = getID( i + 100 )
+
+    with open('idCache\idList.txt', 'a') as idList:
+        idList.write('\n' + id)
+
+    return id
+
+def checkUnique( id ):
+    #open ID List
+    with open('idCache\idList.txt', 'r') as read_obj:
+        #read all lines
+        for line in read_obj:
+            if id in line:
+                return False
+
+    return True
+
+
 def replaceExcept(text: str,
                   old: str | Pattern[str],
                   new: str | Callable[[Match[str]], str],
@@ -376,7 +413,8 @@ def replaceExcept(text: str,
                   allowoverlap: bool = False,
                   marker: str = '',
                   site: pywikibot.site.BaseSite | None = None,
-                  count: int = 0) -> str:
+                  count: int = 0,
+                  appendid: bool = False) -> str:
     """Return text with *old* replaced by *new*, ignoring specified text types.
 
     Skip occurrences of *old* within *exceptions*; e.g. within nowiki
@@ -473,7 +511,10 @@ def replaceExcept(text: str,
                 last = group_match.end()
             replacement += new[last:]
 
-        text = text[:match.start()] + replacement + text[match.end():]
+        if appendid:
+            idText = getID( replaced )
+
+        text = text[:match.start()] + replacement + idText + text[match.end():]
 
         # continue the search on the remaining text
         if allowoverlap:

--- a/pywikibot/textlib.py
+++ b/pywikibot/textlib.py
@@ -395,6 +395,11 @@ def getID( i ):
     return id
 
 def checkUnique( id ):
+    import os
+    # if idList.txt doesn't exist create it
+    if not os.path.exists('/idCache/idList.txt'):
+        with open('idCache/idList.txt', 'x'): pass
+
     #open ID List
     with open('idCache/idList.txt', 'r') as read_obj:
         #read all lines

--- a/scripts/replace.py
+++ b/scripts/replace.py
@@ -102,6 +102,8 @@ Furthermore, the following command line parameters are supported:
 
 -fullsummary      Use one large summary for all command line replacements.
 
+-appendid         append a matchgroup id after each replacement (used for bracket conversions)
+
 
 *Replacement parameters*
     Replacement parameters are pairs of arguments given to the script.
@@ -470,7 +472,8 @@ class XmlDumpReplacePageGenerator:
                     new_text = textlib.replaceExcept(
                         new_text, replacement.old_regex, replacement.new,
                         self.excsInside + replacement.get_inside_exceptions(),
-                        site=self.site)
+                        site=self.site,
+                        appendid=self.opt.appendid)
                 if new_text != entry.text:
                     yield pywikibot.Page(self.site, entry.title)
 
@@ -529,6 +532,8 @@ class ReplaceRobot(SingleSiteBot, ExistingPageBot):
             dictionary in :func:`textlib._create_default_regexes` or must be
             accepted by :func:`textlib.get_regexes`.
 
+    :keyword appendid: append each replacement with a generated matchgroup id
+    :type appendid: bool
     :keyword allowoverlap: when matches overlap, all of them are replaced.
     :type allowoverlap: bool
     :keyword recursive: Recurse replacement as long as possible.
@@ -563,6 +568,7 @@ class ReplaceRobot(SingleSiteBot, ExistingPageBot):
             'recursive': False,
             'sleep': 0.0,
             'summary': None,
+            'appendid': False,
         })
         super().__init__(generator=generator, **kwargs)
 
@@ -640,7 +646,8 @@ class ReplaceRobot(SingleSiteBot, ExistingPageBot):
             new_text = textlib.replaceExcept(
                 new_text, replacement.old_regex, replacement.new,
                 exceptions + replacement.get_inside_exceptions(),
-                allowoverlap=self.opt.allowoverlap, site=self.site)
+                allowoverlap=self.opt.allowoverlap, site=self.site,
+                appendid=self.opt.appendid)
             if old_text != new_text:
                 applied.add(replacement)
 
@@ -969,7 +976,7 @@ def main(*args: str) -> None:
             fixes_set.append(value)
         elif opt == '-sleep':
             options['sleep'] = float(value)
-        elif opt in ('-allowoverlap', '-always', '-quiet', '-recursive'):
+        elif opt in ('-allowoverlap', '-always', '-quiet', '-recursive', '-appendid'):
             options[opt[1:]] = True
         elif opt == '-nocase':
             flags |= re.IGNORECASE


### PR DESCRIPTION
test via `python pwb.py replace -lang:starcraft2 -page:"User:Hjpalpha/wip30" -appendid "test" "test|id=" -summary:"just a test"`
https://liquipedia.net/starcraft2/index.php?title=User%3AHjpalpha%2Fwip30&type=revision&diff=2595818&oldid=2595816

mostly used for rolling out match2 legacy wrappers
but can also be used to replace duplicate ids :P