### PR TITLE
properly initialize idText

### DIFF
--- a/pywikibot/textlib.py
+++ b/pywikibot/textlib.py
@@ -531,6 +531,8 @@ def replaceExcept(text: str,
 
         if appendid:
             idText = getID( replaced )
+        else:
+            idText = ''
 
         text = text[:match.start()] + replacement + idText + text[match.end():]
 


### PR DESCRIPTION
`UnboundLocalError: cannot access local variable 'idText' where it is not associated with a value`

Regression from Liquipedia/pywikibot#3

if `appendid` is `False`, `idText` is never initialized and causes `UnboundLocalError`